### PR TITLE
Enabled an option for twitch chat on the side

### DIFF
--- a/options.html
+++ b/options.html
@@ -24,6 +24,12 @@
 			<input type="checkbox" id="cbNative">
 		 </label>
 		 </p>
+		 <p>
+			<label for="cbTwitch">
+				Enable Twitch Chat:
+			   <input type="checkbox" id="cbTwitch">
+			</label>
+			</p>
 		<button id="saveSettings">Save</button>
 		<span id="status"></span>
   	</body>

--- a/options.js
+++ b/options.js
@@ -2,10 +2,12 @@ function save_options() {
   var v = document.getElementById('hlsjsSel').value;
   var dbg = document.getElementById('cbDebug').checked;
   var ntv = document.getElementById('cbNative').checked;
+  var tch = document.getElementById('cbTwitch').checked;
   chrome.storage.local.set({
     hlsjs: v,
     debug: dbg,
-    native_video: ntv
+    native_video: ntv,
+    twitch_enable: tch
   }, function() {
     var status = document.getElementById('status');
     status.textContent = 'Options saved.';
@@ -19,11 +21,13 @@ function restore_options() {
   chrome.storage.local.get({
     hlsjs: currentVersion,
     debug: false,
-    native_video: false
+    native_video: false,
+    twitch_enable: true
   }, function(items) {
     document.getElementById('hlsjsSel').value = items.hlsjs;
     document.getElementById('cbDebug').checked = items.debug;
     document.getElementById('cbNative').checked = items.native_video;
+    document.getElementById('cbTwitch').checked = items.twitch_enable;
   });
 }
 

--- a/player.html
+++ b/player.html
@@ -6,7 +6,13 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <video id="video" class="zoomed_mode" controls></video>
+  <div id="container">
+    <div id="player">
+        <video id="video" class="native_mode" controls></video>
+    </div>
+    <div id="chat">
+    </div>
+  </div>
   <script src="global.js"></script>
   <script src="player.js"></script>
 </body>

--- a/player.js
+++ b/player.js
@@ -1,5 +1,6 @@
 var hls;
 var debug;
+var twitch_enable;
 var recoverDecodingErrorDate,recoverSwapAudioCodecDate;
 var pendingTimedMetadata = [];
 
@@ -41,15 +42,32 @@ function timeUpdateCallback() {
   console.log('Metadata ' + e.value + " at " + e.pts + "s");
 }
 
-function playM3u8(url){
+function playM3u8(abs_path){
+  var url = abs_path.split('#')[1];
+  var twitch = abs_path.split('#')[2];
   var video = document.getElementById('video');
+  var chat_div = document.getElementById("chat");
+  chat_div.innerHTML = "";
+
   if(native){
     video.classList.add("native_mode");
-    video.classList.remove("zoomed_mode");
+    video.classList.remove("zoomed_mode");;
   } else {
     video.classList.remove("native_mode");
     video.classList.add("zoomed_mode");
   }
+
+  if (twitch_enable == true && twitch != undefined && typeof twitch == "string"){
+    video.className = "twitch_mode";
+    var chat_iframe = document.createElement('iframe');
+    chat_iframe.src = "https://www.twitch.tv/embed/" + twitch + "/chat";
+    chat_iframe.scrolling = "yes";
+    chat_iframe.frameBorder = "0";
+    chat_iframe.id = "chat_embed";
+    chat_iframe.width = "100%";
+    chat_div.append(chat_iframe);
+  }
+
   if(hls){ hls.destroy(); }
   hls = new Hls({debug:debug});
   hls.on(Hls.Events.ERROR, function(event,data) {
@@ -84,20 +102,23 @@ function playM3u8(url){
 chrome.storage.local.get({
   hlsjs: currentVersion,
   debug: false,
-  native: false
+  native: false,
+  twitch_enable: true
 }, function(settings) {
   debug = settings.debug;
   native = settings.native;
+  twitch_enable = settings.twitch_enable;
   var s = document.createElement('script');
   var version = currentVersion
   if (supportedVersions.includes(settings.hlsjs)) {
     version = settings.hlsjs
   }
   s.src = chrome.runtime.getURL('hlsjs/hls.'+version+'.min.js');
-  s.onload = function() { playM3u8(window.location.href.split("#")[1]); };
+  // console.log(window.location.href.split("#"))
+  s.onload = function() { playM3u8(window.location.href); };
   (document.head || document.documentElement).appendChild(s);
 });
 
 $(window).bind('hashchange', function() {
-  playM3u8(window.location.href.split("#")[1]);
+  playM3u8(window.location.href);
 });

--- a/style.css
+++ b/style.css
@@ -1,6 +1,48 @@
-body{
+html, body{
   background-color:black;
+  height: 100%;
+  margin: 0px;
 }
+
+html { 
+  overflow-y: hidden; 
+}
+
+#container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+#player {
+  flex: 0 0 80%;
+  height: 100%
+}
+
+video {
+  height: 100%;
+}
+
+#chat {
+  flex: 1;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
+iframe {
+  height: 100%
+}
+
+.twitch_mode {
+  width: 100%;
+}
+
+/* .twitch_mode {
+  flex: 0 0 80%;
+  height: 100%;
+  width: 100%;
+} */
 
 .native_mode{
   position: absolute;


### PR DESCRIPTION
New setting called enable twitch chat, which allows an additional Hash parameter to be passed, which opens the extension with twitch chat.

![extensionm](https://user-images.githubusercontent.com/47253369/52147500-dd8b6100-26a1-11e9-8b44-829323ceed83.png)
