### PR TITLE
Add enableWorker option.

### DIFF
--- a/options.html
+++ b/options.html
@@ -19,6 +19,12 @@
 		 </label>
 		 </p>
 		 <p>
+		 <label for="cbEnableWorker">
+		 	hls.js enableWorker:
+			<input type="checkbox" id="cbEnableWorker">
+		 </label>
+		 </p>
+		 <p>
 		 <label for="cbNative">
 		 	Maintain original video size:
 			<input type="checkbox" id="cbNative">

--- a/options.js
+++ b/options.js
@@ -1,10 +1,12 @@
 function save_options() {
   var v = document.getElementById('hlsjsSel').value;
   var dbg = document.getElementById('cbDebug').checked;
+  var enableWorker = document.getElementById('cbEnableWorker').checked;
   var ntv = document.getElementById('cbNative').checked;
   chrome.storage.local.set({
     hlsjs: v,
     debug: dbg,
+    enableWorker: enableWorker,
     native_video: ntv
   }, function() {
     var status = document.getElementById('status');
@@ -19,10 +21,12 @@ function restore_options() {
   chrome.storage.local.get({
     hlsjs: currentVersion,
     debug: false,
+    enableWorker: true,
     native_video: false
   }, function(items) {
     document.getElementById('hlsjsSel').value = items.hlsjs;
     document.getElementById('cbDebug').checked = items.debug;
+    document.getElementById('cbEnableWorker').checked = items.enableWorker;
     document.getElementById('cbNative').checked = items.native_video;
   });
 }

--- a/player.js
+++ b/player.js
@@ -1,5 +1,5 @@
 var hls;
-var debug;
+var debug, enableWorker;
 var recoverDecodingErrorDate,recoverSwapAudioCodecDate;
 var pendingTimedMetadata = [];
 
@@ -51,7 +51,7 @@ function playM3u8(url){
     video.classList.add("zoomed_mode");
   }
   if(hls){ hls.destroy(); }
-  hls = new Hls({debug:debug});
+  hls = new Hls({debug:debug, enableWorker: enableWorker});
   hls.on(Hls.Events.ERROR, function(event,data) {
     var  msg = "Player error: " + data.type + " - " + data.details;
     console.error(msg);
@@ -84,9 +84,11 @@ function playM3u8(url){
 chrome.storage.local.get({
   hlsjs: currentVersion,
   debug: false,
+  enableWorker: true,
   native: false
 }, function(settings) {
   debug = settings.debug;
+  enableWorker = settings.enableWorker;
   native = settings.native;
   var s = document.createElement('script');
   var version = currentVersion


### PR DESCRIPTION
Follow #9, Firefox can't play HLS now if `enableWorker` is true in `HlsConfig`.

To be compatible with Chrome, I make `enableWorker` optional and set it to true by default.